### PR TITLE
Correct entry point for the Alpine Dockerfile.

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -10,10 +10,13 @@ RUN apk update && \
         build-base \
         udev 
 
-ADD . /gfsfuse
+COPY . /gfsfuse
 RUN pip3 install -r /gfsfuse/requirements.txt
-# mount point
-RUN mkdir /gfs
-WORKDIR gfsfuse
 
-CMD ["bash", "/gfsfuse/docker_start_gfsfuse.sh"]
+# ENV GFSAPI_HOST=10.88.88.183
+# ENV GFSAPI_USER=
+# ENV GFSAPI_PASSWORD=
+ENV GFSAPI_HOST=gfs-api
+ENV GFSAPI_PORT=5000
+
+ENTRYPOINT ["/gfsfuse/bootstrap.sh"]


### PR DESCRIPTION
I think the Alpine Dockerfile was left out and not updated. The Debian one seems more current as it at least has the right entrypoint. I am thus updating the Alpine Dockerfile with the entrypoint from the Debian Dockerfile.