### PR TITLE
Set up the project and mount point at build time.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,8 +3,8 @@
 CONTAINER_IP=$(cat /etc/hosts | grep 172 | cut -f 1 -d$'\t')
 echo "Found IP of container: $CONTAINER_IP"
 
-GFS_MOUNTPOINT="/gfs"
-mkdir -p $GFS_MOUNTPOINT
+# GFS_MOUNTPOINT="/gfs"
+# mkdir -p $GFS_MOUNTPOINT
 
 # GFSAPI_HOST=${GFSAPI_HOST:-10.88.88.183}
 # GFSAPI_USER=${GFSAPI_USER:-...}

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -10,9 +10,6 @@ RUN apk update && \
         build-base \
         udev 
 
-COPY . /gfsfuse
-RUN pip3 install -r /gfsfuse/requirements.txt
-
 # RUN addgroup --system --gid 1001 gfs
 RUN addgroup -S gfs -g 1001
 
@@ -24,5 +21,13 @@ RUN adduser -S gfs -u 1001 -G gfs; echo 'gfs:gfsgfs' | chpasswd
 # ENV GFSAPI_PASSWORD=
 ENV GFSAPI_HOST=gfs-api
 ENV GFSAPI_PORT=5000
+ENV GFS_MOUNTPOINT="/gfs"
+RUN mkdir -p $GFS_MOUNTPOINT; chown gfs:gfs $GFS_MOUNTPOINT
+
+COPY . /gfsfuse
+RUN pip3 install -r /gfsfuse/requirements.txt
+RUN chown -R gfs:gfs /gfsfuse
+
+USER gfs
 
 ENTRYPOINT ["/gfsfuse/bootstrap.sh"]

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -6,9 +6,6 @@ RUN apt install -y \
     libfuse-dev \
     fuse 
 
-COPY . /gfsfuse
-RUN pip3 install -r /gfsfuse/requirements.txt
-
 RUN addgroup --system --gid 1001 gfs
 RUN useradd --uid 1001 --gid 1001 gfs -p gfsgfs
 
@@ -17,5 +14,13 @@ RUN useradd --uid 1001 --gid 1001 gfs -p gfsgfs
 # ENV GFSAPI_PASSWORD=
 ENV GFSAPI_HOST=gfs-api
 ENV GFSAPI_PORT=5000
+ENV GFS_MOUNTPOINT="/gfs"
+RUN mkdir -p $GFS_MOUNTPOINT; chown gfs:gfs $GFS_MOUNTPOINT
+
+COPY . /gfsfuse
+RUN pip3 install -r /gfsfuse/requirements.txt
+RUN chown -R gfs:gfs /gfsfuse
+
+USER gfs
 
 ENTRYPOINT ["/gfsfuse/bootstrap.sh"]


### PR DESCRIPTION
I believe it is better to set up the py project and fuse mount point at build time instead of at runtime. This way we can set it up as root and chown it to the local user during build time, then we can boot as the local user and everything should be set up.