### PR TITLE
New service start script.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# 
+docker run \
+	-e GFSAPI_HOST='gfs.labber.io' \
+	-e GFSAPI_PORT='80' \
+	--add-host gfs.labber.io:10.88.88.191 \
+	--rm -it \
+	--privileged --device /dev/fuse --cap-add SYS_ADMIN \
+	--entrypoint bash buildregistry.localdomain/gfs-fuse:debian-latest
+


### PR DESCRIPTION
With this script I can correctly boot a fuse mounter service and manually start the fuse mount by running sudo /gfsfuse/bootstrap.sh at the prompt.