### PR TITLE
Upgrading Alpine Docker build to Python 3.8.

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,5 @@
-FROM python:3.6.12-alpine3.11
+# FROM python:3.6.12-alpine3.11
+FROM python:3.8.7-alpine3.11
 
 RUN apk update && \
     apk add \


### PR DESCRIPTION
Upgrading Alpine Docker build to Python 3.8 to better match the Theia 1.18 build.