### PR TITLE
Upgrading Alpine Docker build to Alpine 3.15 and Python 3.9.

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,5 +1,6 @@
 # FROM python:3.6.12-alpine3.11
-FROM python:3.8.7-alpine3.11
+# FROM python:3.8.7-alpine3.11
+FROM python:3.9.15-alpine3.15
 
 RUN apk update && \
     apk add \


### PR DESCRIPTION
Upgrading Alpine Docker build to Alpine 3.15 and Python 3.9 to better match the Theia 1.25 build.