### PR TITLE
Automatically tag Theia latest as latest.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,3 +19,7 @@ image() {
 image "alpine"
 image "debian"
 image "theia"
+
+LATEST_THEIA_IMAGE="${LOCAL_REGISTRY}/gfs-fuse:theia-latest"
+LATEST_IMAGE="${LOCAL_REGISTRY}/gfs-fuse:latest"
+docker tag $LATEST_THEIA_IMAGE $LATEST_IMAGE


### PR DESCRIPTION
One of these builds should be tagged latest, and that will be the Theia build for now. The Theia build is the easiest to use as it comes with a full blown web accessible IDE, including a terminal!